### PR TITLE
Completing actions from 2023-01-26 steering committee meeting

### DIFF
--- a/projects-list/README.md
+++ b/projects-list/README.md
@@ -17,17 +17,17 @@ These are all the projects that are currently in some state ranging from "ideati
 
 | Project Name | Label | Description | Community Group | State
 | --- | --- | --- | --- | --- |
+| Console General Availability | console-ga | Releasing Console for General Availability | [sig-clients](../sig-clients/README.md) | implementation |
+| Economics 2.0 | econ-2.0 | Redesigning Akash Network's economics model to have fine grained take rates to fund product development and sustainability of the chain  | [sig-economics](../sig-economics/README.md) | spec-definition |
+| [GPU Support](../wg-gpu/prd.md) | gpu | Everything related to supporting, launching and growing GPUs on Akash  | [wg-gpu](../wg-gpu) | implementation |
 | Provider Services Microservices Refactor | provider-svc-split | Splitting Akash Provider Services into microservices so that we’re able to release and maintain software better | [sig-providers](..//sig-providers) | implementation |
-| Certification Program | edu-cert-prgm | Define, build and finalize Akash Network Certification Program  | [sig-community](https://github.com/akash-network/community/tree/main/sig-community) | implementation |
-| Console General Availability | console-ga | Releasing Console for General Availability | [sig-clients](https://github.com/akash-network/community/tree/main/sig-clients) | implementation |
-| Docs site migration | docs-site-migration | Migrating the documentation site from gitbooks to something automatable (Hugo?) | [sig-docs](https://github.com/akash-network/community/tree/main/sig-documentation) | spec-definition |
-| [Console Authorized Spend Support](../sig-clients/akash-console/prd-authorized-spend.md) | console-authz | Supporting Authorized Spend (AuthZ) in Akash Console | [sig-clients](https://github.com/akash-network/community/tree/main/sig-clients) | spec-definition |
-| [Client Libraries](https://github.com/akash-network/community/blob/main/sig-clients/client-libraries/prd.md) | client-libs |  Libraries for deploying on Akash programmatically using various programming languages  | [sig-clients](https://github.com/akash-network/community/tree/main/sig-clients) | spec-definition |
-| GPU Support | gpu | Everything related to supporting, launching and growing GPUs on Akash  | [wg-gpu](../wg-gpu) | spec-definition |
-| Provider Attributes | provider-attr | Defining an attribute schema for providers and getting providers to incorporate it  | [wg-provider-attributes](../wg-provider-attributes/README.md) | spec-definition |
-| Economics 2.0 | econ-2.0 | Redesigning Akash Network's economics model to have fine grained take rates to fund product development and sustainability of the chain  | [sig-economics](https://github.com/akash-network/community/tree/main/sig-economics) | spec-definition |
-| Omnibus Maintenance | omnibus-maint | Building new reference SDLs and packages for new chains that we want to support. Building automated testing for the supported omnibus chains  | [sig-community](https://github.com/akash-network/community/tree/main/sig-community) | ideation |
 | Content Moderation | content-mod | Tools and process for ensuring that providers have visibility into workloads running on them and controls to ensure they don’t violate their terms of service  | [sig-providers](../sig-providers) | ideation |
+| [Client Libraries](https://github.com/akash-network/community/blob/main/sig-clients/client-libraries/prd.md) | client-libs |  Libraries for deploying on Akash programmatically using various programming languages  | [sig-clients](../sig-clients/README.md) | spec-definition |
+| [Console Authorized Spend Support](../sig-clients/akash-console/prd-authorized-spend.md) | console-authz | Supporting Authorized Spend (AuthZ) in Akash Console | [sig-clients](../sig-clients/README.md) | spec-definition |
+| Provider Attributes | provider-attr | Defining an attribute schema for providers and getting providers to incorporate it  | [wg-provider-attributes](../wg-provider-attributes/README.md) | spec-definition |
+| Certification Program | edu-cert-prgm | Define, build and finalize Akash Network Certification Program  | sig-edu | implementation |
+| Docs site migration | docs-site-migration | Migrating the documentation site from gitbooks to something automatable (Hugo?) | sig-docs | spec-definition |
+| Omnibus Maintenance | omnibus-maint | Building new reference SDLs and packages for new chains that we want to support. Building automated testing for the supported omnibus chains  | sig-community | ideation |
 | Keeping up with Cosmos | cosmos-sync | Things we Akash needs to do to stay in sync with Cosmos (SDK changes etc)  | sig-network-upgrade  |  |
 | Private Image Repository |  | Support for deploying  images hosted in private container registries |  |  |
 | CI/ CD Workflows |  | Things necessary to support CI/ CD style deployments on Akash  | |  |

--- a/wg-provider-monitoring/README.md
+++ b/wg-provider-monitoring/README.md
@@ -1,0 +1,34 @@
+---
+title: "Provider Monitoring Working Group"
+date: 2023-1-10T00:19:20-08:00
+---
+
+# Akash Network Provider Monitoring Working Group
+
+This working group is for defining any specifications and scope of code changes for making it easy to monitor providers. Note that this working group does not deal with provider analytics but is considered with pure monitoring of the infrastructure (for improved uptime, SLA and such)
+
+## Meetings
+
+To be scheduled
+
+## Lead(s)
+
+- Anil Murty, Overclock Labs (@anilmurty)
+- Jigar Patel, Praetor App (@jigar-arc10)
+- Joao Luna, Quasarch (@cloud-j-luna)
+
+## Contacts
+
+- [Discord](https://discord.com/channels/747885925232672829/1070501619625623633)
+
+## Goals
+
+- Discuss challenges of monitoring providers
+- Write spec
+
+## PRDs and other documentation
+TBD
+
+## Related SIGs
+
+- [sig-provider](../sig-providers/README.md)


### PR DESCRIPTION
All [actions](https://github.com/akash-network/community/blob/main/committee-steering/meetings/001-2023-01-26.md) from the 2023-01-26 SC meeting are now complete:

- Anil is going to reorder [project list](https://github.com/akash-network/community/tree/main/projects-list) by priority -- included in this PR
- Luna will add a new special interest group for sig-design -- https://github.com/akash-network/community/pull/17
- Anil will make a repo for the Steering Committee -- https://github.com/akash-network/community/pull/14
- A user will create a Security User group called ug-security. https://discord.com/channels/747885925232672829/1070496506131525672
- Anil will make a working group for provider monitoring called wg-provider-monitoring -- included in this PR